### PR TITLE
feat: modernize theme and workflows with dark mode

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,12 +1,11 @@
 // App.tsx
 import React, { useEffect } from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { Provider as PaperProvider } from 'react-native-paper';
 import { StatusBar } from 'expo-status-bar';
 import { AuthProvider } from './src/contexts/AuthContext';
 import { CartProvider } from './src/contexts/CartContext';
 import { AppNavigator } from './src/navigation/AppNavigator';
-import { theme } from './src/theme/theme';
+import { ThemeProvider } from './src/contexts/ThemeContext';
 import { testConnection } from './src/api/apiConfig';
 
 export default function App() {
@@ -14,17 +13,17 @@ export default function App() {
   testConnection().then(connected => {
     console.log('API connection status:', connected);
   });
-}, []);
+  }, []);
   return (
     <SafeAreaProvider>
-      <PaperProvider theme={theme}>
+      <ThemeProvider>
         <StatusBar style="auto" />
         <AuthProvider>
           <CartProvider>
             <AppNavigator />
           </CartProvider>
         </AuthProvider>
-      </PaperProvider>
+      </ThemeProvider>
     </SafeAreaProvider>
   );
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "expo-dev-client": "~5.2.0",
     "expo-secure-store": "~14.2.3",
     "expo-status-bar": "~2.2.3",
+    "expo-blur": "~13.0.2",
     "expo-updates": "~0.28.14",
     "formik": "^2.4.6",
     "js-cookie": "^3.0.5",

--- a/src/components/common/GlassSurface.tsx
+++ b/src/components/common/GlassSurface.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { StyleSheet, StyleProp, ViewStyle } from 'react-native';
+import { BlurView } from 'expo-blur';
+import { useTheme } from 'react-native-paper';
+
+interface GlassSurfaceProps {
+  children: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+  intensity?: number;
+}
+
+const GlassSurface: React.FC<GlassSurfaceProps> = ({ children, style, intensity = 50 }) => {
+  const theme = useTheme();
+  const backgroundColor = theme.dark ? 'rgba(0,0,0,0.3)' : 'rgba(255,255,255,0.3)';
+  const borderColor = theme.dark ? 'rgba(255,255,255,0.1)' : 'rgba(255,255,255,0.4)';
+  return (
+    <BlurView
+      intensity={intensity}
+      tint={theme.dark ? 'dark' : 'light'}
+      style={[
+        styles.container,
+        { backgroundColor, borderColor, borderRadius: theme.roundness },
+        style,
+      ]}
+    >
+      {children}
+    </BlurView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: 1,
+  },
+});
+
+export default GlassSurface;

--- a/src/components/kitchen/KitchenFilter.tsx
+++ b/src/components/kitchen/KitchenFilter.tsx
@@ -1,7 +1,8 @@
 // src/components/kitchen/KitchenFilter.tsx
 import React from 'react';
 import { View, StyleSheet, ScrollView, Dimensions } from 'react-native';
-import { Chip, Text, Surface, useTheme } from 'react-native-paper';
+import { Chip, Text, useTheme } from 'react-native-paper';
+import GlassSurface from '../common/GlassSurface';
 
 interface KitchenFilterProps {
   categories: string[];
@@ -23,7 +24,7 @@ export const KitchenFilter: React.FC<KitchenFilterProps> = ({
   const isLandscape = windowWidth > windowHeight;
 
   return (
-    <Surface style={[styles.container, isTablet && styles.tabletContainer]}>
+    <GlassSurface style={[styles.container, isTablet && styles.tabletContainer]}>
       <Text style={[styles.label, isTablet && styles.tabletLabel]}>Filtrer par catégorie:</Text>
       <ScrollView 
         horizontal 
@@ -54,7 +55,7 @@ export const KitchenFilter: React.FC<KitchenFilterProps> = ({
           </Chip>
         ))}
       </ScrollView>
-    </Surface>
+    </GlassSurface>
   );
 };
 

--- a/src/components/kitchen/OrderCard.tsx
+++ b/src/components/kitchen/OrderCard.tsx
@@ -2,7 +2,6 @@
 import React, { useState } from "react";
 import { View, StyleSheet, TouchableOpacity } from "react-native";
 import {
-  Card,
   Text,
   Button,
   Chip,
@@ -12,9 +11,9 @@ import {
   List,
   Modal,
   Portal,
-  Surface,
   useTheme,
 } from "react-native-paper";
+import GlassSurface from "../common/GlassSurface";
 import Icon from "react-native-vector-icons/MaterialCommunityIcons";
 import { DomainOrder, DomainOrderItem } from "../../api/orderService";
 
@@ -131,8 +130,8 @@ export const OrderCard: React.FC<OrderCardProps> = ({
       
       {/* Contenu de la carte avec shadow */}
       <View style={styles.cardContainer}>
-        <Card style={styles.card}>
-          <Card.Content style={styles.cardContent}>
+        <GlassSurface style={styles.card}>
+          <View style={styles.cardContent}>
             <View style={styles.headerRow}>
               <View style={styles.orderInfo}>
                 <Text style={styles.orderNumber}>Commande #{order.id}</Text>
@@ -245,8 +244,8 @@ export const OrderCard: React.FC<OrderCardProps> = ({
                 </View>
               </View>
             )}
-          </Card.Content>
-        </Card>
+          </View>
+        </GlassSurface>
       </View>
 
       {/* Modal de confirmation */}
@@ -256,7 +255,7 @@ export const OrderCard: React.FC<OrderCardProps> = ({
           onDismiss={() => setConfirmModalVisible(false)}
           contentContainerStyle={styles.modalContainer}
         >
-          <Surface style={styles.modalContent}>
+          <GlassSurface style={styles.modalContent}>
             <Text style={styles.modalTitle}>
               {actionType === "ready"
                 ? "Marquer comme prêt"
@@ -287,7 +286,7 @@ export const OrderCard: React.FC<OrderCardProps> = ({
                 Confirmer
               </Button>
             </View>
-          </Surface>
+          </GlassSurface>
         </Modal>
       </Portal>
     </View>

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { Provider as PaperProvider } from 'react-native-paper';
+import { lightTheme, darkTheme, AppTheme } from '../theme/theme';
+
+interface ThemeContextType {
+  isDarkMode: boolean;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType>({
+  isDarkMode: false,
+  toggleTheme: () => {},
+});
+
+export const useThemeToggle = () => useContext(ThemeContext);
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [isDarkMode, setIsDarkMode] = useState(false);
+
+  const toggleTheme = () => setIsDarkMode((prev) => !prev);
+
+  const theme: AppTheme = isDarkMode ? darkTheme : lightTheme;
+
+  return (
+    <ThemeContext.Provider value={{ isDarkMode, toggleTheme }}>
+      <PaperProvider theme={theme}>{children}</PaperProvider>
+    </ThemeContext.Provider>
+  );
+};
+
+export { ThemeContext };

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -20,6 +20,7 @@ import { CloseWithDebtScreen } from "../screens/server/CloseWithDebtScreen";
 import { PendingValidationsScreen } from "../screens/manager/PendingValidationsScreen";
 import { useAuth } from "../contexts/AuthContext";
 import { ActivityIndicator, View, StyleSheet, Text } from "react-native";
+import { useTheme } from "react-native-paper";
 
 
 // Types des paramètres pour les routes d'authentification
@@ -85,11 +86,12 @@ const MainStack = createStackNavigator<MainStackParamList>();
 
 // Composant pour les routes d'authentification
 const AuthNavigator = () => {
+  const theme = useTheme();
   return (
     <AuthStack.Navigator
       screenOptions={{
         headerShown: false,
-        cardStyle: { backgroundColor: "#f5f5f5" },
+        cardStyle: { backgroundColor: theme.colors.background },
       }}
     >
       <AuthStack.Screen name="Login" component={LoginScreen} />
@@ -100,6 +102,7 @@ const AuthNavigator = () => {
 // Composant pour les routes principales (authentifiées)
 const MainNavigator: React.FC = () => {
   const { user } = useAuth();
+  const theme = useTheme();
 
   // Déterminer l'écran initial en fonction du rôle de l'utilisateur
   const getInitialRouteName = () => {
@@ -119,7 +122,7 @@ const MainNavigator: React.FC = () => {
       initialRouteName={initialRoute}
       screenOptions={{
         headerShown: false,
-        cardStyle: { backgroundColor: "#f5f5f5" },
+        cardStyle: { backgroundColor: theme.colors.background },
       }}
     >
       <MainStack.Screen name="ServerHome" component={ServerHomeScreen} />
@@ -145,13 +148,16 @@ const MainNavigator: React.FC = () => {
 // Composant de navigation principale
 export const AppNavigator: React.FC = () => {
   const { user, isLoading } = useAuth();
+  const theme = useTheme();
 
   // Afficher un indicateur de chargement pendant la vérification de l'authentification
   if (isLoading) {
     return (
-      <View style={styles.loadingContainer}>
-        <ActivityIndicator size="large" color="#0066CC" />
-        <Text style={styles.loadingText}>Chargement...</Text>
+      <View
+        style={[styles.loadingContainer, { backgroundColor: theme.colors.background }]}
+      >
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+        <Text style={[styles.loadingText, { color: theme.colors.primary }]}>Chargement...</Text>
       </View>
     );
   }
@@ -168,11 +174,9 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
-    backgroundColor: "#f5f5f5",
   },
   loadingText: {
     marginTop: 16,
     fontSize: 16,
-    color: "#0066CC",
   },
 });

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -8,17 +8,15 @@ import {
   KeyboardAvoidingView,
   Platform,
   ScrollView,
-  Image,
 } from "react-native";
 import {
   TextInput,
   Button,
   Text,
-  Snackbar,
-  Surface,
-  ActivityIndicator,
   Banner,
+  useTheme,
 } from "react-native-paper";
+import GlassSurface from "../components/common/GlassSurface";
 import { Formik } from "formik";
 import * as Yup from "yup";
 import { useAuth } from "../contexts/AuthContext";
@@ -32,6 +30,7 @@ const LoginSchema = Yup.object().shape({
 // Composant écran de connexion
 export const LoginScreen: React.FC = () => {
   const { login, error, clearError, isLoading, forceLogoutReason, clearForceLogoutReason } = useAuth();
+  const theme = useTheme();
   const [secureTextEntry, setSecureTextEntry] = useState(true);
   const [localError, setLocalError] = useState<string | null>(null);
 
@@ -74,15 +73,15 @@ export const LoginScreen: React.FC = () => {
   return (
     <KeyboardAvoidingView
       behavior={Platform.OS === "ios" ? "padding" : "height"}
-      style={styles.container}
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
     >
       <ScrollView
         contentContainerStyle={styles.scrollContainer}
         keyboardShouldPersistTaps="handled"
       >
-        <Surface style={styles.surface}>
+        <GlassSurface style={[styles.surface]}> 
           <View style={styles.logoContainer}>
-            <Text style={styles.logoText}>Mokengeli Biloko POS</Text>
+            <Text style={[styles.logoText, { color: theme.colors.primary }]}>Mokengeli Biloko POS</Text>
           </View>
 
           {/* Bannière pour le message de déconnexion forcée */}
@@ -95,10 +94,10 @@ export const LoginScreen: React.FC = () => {
                   onPress: clearForceLogoutReason,
                 },
               ]}
-              style={styles.forceLogoutBanner}
+              style={[styles.forceLogoutBanner, { backgroundColor: `${theme.colors.warning}20` }]}
               icon="alert-circle"
             >
-              <Text style={styles.forceLogoutText}>{forceLogoutReason}</Text>
+              <Text style={[styles.forceLogoutText, { color: theme.colors.warning }]}>{forceLogoutReason}</Text>
             </Banner>
           )}
 
@@ -111,14 +110,14 @@ export const LoginScreen: React.FC = () => {
                   onPress: clearError,
                 },
               ]}
-              style={styles.errorBanner}
+              style={[styles.errorBanner, { backgroundColor: `${theme.colors.error}20` }]}
               icon="alert-circle"
             >
-              <Text style={styles.errorBannerText}>{showError}</Text>
+              <Text style={[styles.errorBannerText, { color: theme.colors.error }]}>{showError}</Text>
             </Banner>
           )}
 
-          <Text style={styles.title}>Connexion</Text>
+          <Text style={[styles.title, { color: theme.colors.text }]}>Connexion</Text>
 
           <Formik
             initialValues={{
@@ -149,7 +148,7 @@ export const LoginScreen: React.FC = () => {
                   disabled={isLoading}
                 />
                 {touched.username && errors.username && (
-                  <Text style={styles.errorText}>{errors.username}</Text>
+                  <Text style={[styles.errorText, { color: theme.colors.error }]}>{errors.username}</Text>
                 )}
 
                 <TextInput
@@ -169,7 +168,7 @@ export const LoginScreen: React.FC = () => {
                   disabled={isLoading}
                 />
                 {touched.password && errors.password && (
-                  <Text style={styles.errorText}>{errors.password}</Text>
+                  <Text style={[styles.errorText, { color: theme.colors.error }]}>{errors.password}</Text>
                 )}
 
                 <Button
@@ -184,7 +183,7 @@ export const LoginScreen: React.FC = () => {
               </View>
             )}
           </Formik>
-        </Surface>
+        </GlassSurface>
       </ScrollView>
     </KeyboardAvoidingView>
   );
@@ -193,7 +192,6 @@ export const LoginScreen: React.FC = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#f5f5f5",
   },
   scrollContainer: {
     flexGrow: 1,
@@ -203,7 +201,6 @@ const styles = StyleSheet.create({
   },
   surface: {
     padding: 30,
-    borderRadius: 10,
     elevation: 4,
     width: "100%",
     maxWidth: 400,
@@ -215,7 +212,6 @@ const styles = StyleSheet.create({
   logoText: {
     fontSize: 28,
     fontWeight: "bold",
-    color: "#0066CC",
   },
   title: {
     fontSize: 24,
@@ -231,25 +227,18 @@ const styles = StyleSheet.create({
     backgroundColor: "transparent",
   },
   errorText: {
-    color: "#B00020",
     fontSize: 12,
     marginBottom: 10,
     marginLeft: 5,
   },
   errorBanner: {
     marginBottom: 20,
-    backgroundColor: "#FFECEC",
   },
-  errorBannerText: {
-    color: "#B00020",
-  },
+  errorBannerText: {},
   forceLogoutBanner: {
     marginBottom: 20,
-    backgroundColor: "#FFF3E0", // Orange clair pour déconnexion forcée
   },
-  forceLogoutText: {
-    color: "#E65100", // Orange foncé
-  },
+  forceLogoutText: {},
   button: {
     marginTop: 20,
     paddingVertical: 6,

--- a/src/screens/ProfilScreen.tsx
+++ b/src/screens/ProfilScreen.tsx
@@ -3,23 +3,26 @@ import React from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import {
   Text,
-  Surface,
   Button,
-  Card,
   Divider,
   Chip,
   Appbar,
   List,
+  Switch,
+  useTheme,
 } from "react-native-paper";
+import GlassSurface from "../components/common/GlassSurface";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useAuth } from "../contexts/AuthContext";
-import { RolesUtils, Role } from "../utils/roles";
+import { RolesUtils } from "../utils/roles";
 import { useNavigation } from "@react-navigation/native";
-import Icon from "react-native-vector-icons/MaterialCommunityIcons";
+import { useThemeToggle } from "../contexts/ThemeContext";
 
 export const ProfilScreen: React.FC = () => {
   const { user, logout, isLoading } = useAuth();
   const navigation = useNavigation();
+  const { isDarkMode, toggleTheme } = useThemeToggle();
+  const theme = useTheme();
 
   const handleLogout = async () => {
     await logout();
@@ -48,7 +51,10 @@ export const ProfilScreen: React.FC = () => {
   };
 
   return (
-    <SafeAreaView style={styles.container} edges={["left", "right"]}>
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
+      edges={["left", "right"]}
+    >
       <Appbar.Header>
         <Appbar.BackAction onPress={() => navigation.goBack()} />
         <Appbar.Content title="Mon profil" />
@@ -60,9 +66,11 @@ export const ProfilScreen: React.FC = () => {
         contentContainerStyle={styles.contentContainer}
       >
         {/* En-tête du profil */}
-        <Surface style={styles.profileHeader} elevation={2}>
+        <GlassSurface
+          style={[styles.profileHeader]}
+        >
           <View style={styles.avatarContainer}>
-            <View style={styles.avatar}>
+            <View style={[styles.avatar, { backgroundColor: theme.colors.primary }]}> 
               <Text style={styles.avatarText}>
                 {getFullName().charAt(0).toUpperCase()}
               </Text>
@@ -70,11 +78,26 @@ export const ProfilScreen: React.FC = () => {
           </View>
           <Text style={styles.userName}>{getFullName()}</Text>
           {user?.email && <Text style={styles.userEmail}>{user.email}</Text>}
-        </Surface>
+        </GlassSurface>
+
+        {/* Préférences */}
+        <GlassSurface style={styles.card}>
+            <Text style={styles.sectionTitle}>Préférences</Text>
+            <Divider style={styles.divider} />
+            <List.Section>
+              <List.Item
+                title="Mode sombre"
+                left={(props) => <List.Icon {...props} icon="theme-light-dark" />}
+                right={() => (
+                  <Switch value={isDarkMode} onValueChange={toggleTheme} />
+                )}
+                titleStyle={styles.listItemTitle}
+              />
+            </List.Section>
+        </GlassSurface>
 
         {/* Informations personnelles */}
-        <Card style={styles.card}>
-          <Card.Content>
+        <GlassSurface style={styles.card}>
             <Text style={styles.sectionTitle}>Informations personnelles</Text>
             <Divider style={styles.divider} />
 
@@ -98,25 +121,21 @@ export const ProfilScreen: React.FC = () => {
                 titleStyle={styles.listItemTitle}
               />
             </List.Section>
-          </Card.Content>
-        </Card>
+        </GlassSurface>
 
         {/* Rôles et permissions */}
-        <Card style={styles.card}>
-          <Card.Content>
+        <GlassSurface style={styles.card}>
             <Text style={styles.sectionTitle}>Rôles et permissions</Text>
             <Divider style={styles.divider} />
 
             <View style={styles.rolesContainer}>
               {formatRoles(user?.roles)}
             </View>
-          </Card.Content>
-        </Card>
+        </GlassSurface>
 
         {/* Informations du restaurant */}
         {user?.tenantName && (
-          <Card style={styles.card}>
-            <Card.Content>
+          <GlassSurface style={styles.card}>
               <Text style={styles.sectionTitle}>Restaurant</Text>
               <Divider style={styles.divider} />
 
@@ -136,8 +155,7 @@ export const ProfilScreen: React.FC = () => {
                   />
                 )}
               </List.Section>
-            </Card.Content>
-          </Card>
+          </GlassSurface>
         )}
 
         {/* Bouton de déconnexion */}
@@ -159,7 +177,6 @@ export const ProfilScreen: React.FC = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#f5f5f5",
   },
   scrollView: {
     flex: 1,
@@ -173,7 +190,6 @@ const styles = StyleSheet.create({
     padding: 24,
     alignItems: "center",
     marginBottom: 24,
-    backgroundColor: "white",
   },
   avatarContainer: {
     marginBottom: 16,
@@ -182,7 +198,6 @@ const styles = StyleSheet.create({
     width: 80,
     height: 80,
     borderRadius: 40,
-    backgroundColor: "#0066CC",
     justifyContent: "center",
     alignItems: "center",
   },
@@ -203,6 +218,7 @@ const styles = StyleSheet.create({
   card: {
     marginBottom: 16,
     borderRadius: 12,
+    padding: 16,
   },
   sectionTitle: {
     fontSize: 18,

--- a/src/screens/kitchen/KitchenHomeScreen.tsx
+++ b/src/screens/kitchen/KitchenHomeScreen.tsx
@@ -457,7 +457,10 @@ export const KitchenHomeScreen = () => {
   }
 
   return (
-    <SafeAreaView style={styles.container} edges={["left", "right"]}>
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
+      edges={["left", "right"]}
+    >
       <Appbar.Header style={styles.appbar}>
         {/* Bouton de retour pour les managers */}
         {isManager && (
@@ -500,7 +503,15 @@ export const KitchenHomeScreen = () => {
           />
         )}
         renderSectionHeader={({ section: { title } }) => (
-          <View style={styles.sectionHeader}>
+          <View
+            style={[
+              styles.sectionHeader,
+              {
+                backgroundColor: theme.colors.background,
+                borderBottomColor: theme.colors.disabled,
+              },
+            ]}
+          >
             <Text style={styles.sectionTitle}>{title}</Text>
             <Divider style={styles.divider} />
           </View>
@@ -531,7 +542,9 @@ export const KitchenHomeScreen = () => {
           visible={errorDialog.visible}
           onDismiss={() => setErrorDialog({ ...errorDialog, visible: false })}
         >
-          <Dialog.Title style={styles.errorDialogTitle}>
+          <Dialog.Title
+            style={[styles.errorDialogTitle, { color: theme.colors.error }]}
+          >
             {errorDialog.title}
           </Dialog.Title>
           <Dialog.Content>
@@ -560,7 +573,7 @@ export const KitchenHomeScreen = () => {
         visible={infoSnackbar.visible}
         onDismiss={() => setInfoSnackbar({ ...infoSnackbar, visible: false })}
         duration={3000}
-        style={styles.infoSnackbar}
+        style={[styles.infoSnackbar, { backgroundColor: theme.colors.accent }]}
       >
         {infoSnackbar.message}
       </Snackbar>
@@ -573,7 +586,7 @@ export const KitchenHomeScreen = () => {
           label: "Réessayer",
           onPress: onRefresh,
         }}
-        style={styles.errorSnackbar}
+        style={[styles.errorSnackbar, { backgroundColor: theme.colors.error }]}
       >
         {snackbarError.message}
       </Snackbar>
@@ -584,7 +597,6 @@ export const KitchenHomeScreen = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#f5f5f5",
   },
   appbar: {
     height: 56,
@@ -600,11 +612,9 @@ const styles = StyleSheet.create({
     fontSize: 16,
   },
   sectionHeader: {
-    backgroundColor: "#f5f5f5",
     paddingHorizontal: 16,
     paddingVertical: 8,
     borderBottomWidth: 1,
-    borderBottomColor: "#e0e0e0",
   },
   sectionTitle: {
     fontSize: 18,
@@ -631,15 +641,12 @@ const styles = StyleSheet.create({
     opacity: 0.7,
   },
   errorDialogTitle: {
-    color: "#D32F2F",
   },
   errorDialogMessage: {
     fontSize: 16,
   },
   errorSnackbar: {
-    backgroundColor: "#D32F2F",
   },
   infoSnackbar: {
-    backgroundColor: "#4CAF50", // Vert pour les mises à jour
   },
 });

--- a/src/screens/server/CreateOrderScreen.tsx
+++ b/src/screens/server/CreateOrderScreen.tsx
@@ -174,7 +174,10 @@ const handleCancelOrder = () => {
   // Si les catégories sont en cours de chargement
   if (isLoadingCategories && categories.length === 0) {
     return (
-      <SafeAreaView style={styles.container} edges={['left', 'right']}>
+      <SafeAreaView
+        style={[styles.container, { backgroundColor: theme.colors.background }]}
+        edges={['left', 'right']}
+      >
         <Appbar.Header style={[styles.appbar, { backgroundColor: theme.colors.primary }]}>
           <Appbar.BackAction color="white" onPress={() => navigation.goBack()} />
           <Appbar.Content title={`Nouvelle commande - ${tableName}`} titleStyle={{ color: 'white' }} />
@@ -189,15 +192,28 @@ const handleCancelOrder = () => {
   }
   
   return (
-    <SafeAreaView style={styles.container} edges={['left', 'right']}>
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
+      edges={['left', 'right']}
+    >
       <Appbar.Header style={[styles.appbar, { backgroundColor: theme.colors.primary }]}>
         <Appbar.BackAction color="white" onPress={() => navigation.goBack()} />
         <Appbar.Content title={`Nouvelle commande - ${tableName}`} titleStyle={{ color: 'white' }} />
       </Appbar.Header>
       
       {error ? (
-        <Surface style={styles.errorContainer}>
-          <Text style={styles.errorText}>{error}</Text>
+        <Surface
+          style={[
+            styles.errorContainer,
+            {
+              backgroundColor: theme.colors.error + '20',
+              borderRadius: theme.roundness,
+            },
+          ]}
+        >
+          <Text style={[styles.errorText, { color: theme.colors.error }]}>
+            {error}
+          </Text>
         </Surface>
       ) : (
         <View style={styles.content}>
@@ -323,18 +339,28 @@ const handleCancelOrder = () => {
               <FlatList
                 data={dishes}
                 renderItem={({ item }) => (
-                  <Card style={styles.dishCard} elevation={3}>
+                  <Card
+                    style={[styles.dishCard, { borderLeftColor: theme.colors.accent }]}
+                    elevation={3}
+                  >
                     <Card.Content>
                       <View style={styles.dishHeader}>
                         <Text style={styles.dishName}>{item.name}</Text>
-                        <Text style={styles.dishPrice}>
+                        <Text style={[styles.dishPrice, { color: theme.colors.accent }]}>
                           {item.price.toFixed(2)} {item.currency.code}
                         </Text>
                       </View>
                       {item.categories && item.categories.length > 0 && (
                         <View style={styles.dishCategories}>
                           {item.categories.map((cat, index) => (
-                            <Chip key={index} style={styles.dishCategoryChip} textStyle={{ fontSize: 10 }}>
+                            <Chip
+                              key={index}
+                              style={[
+                                styles.dishCategoryChip,
+                                { backgroundColor: theme.colors.accent + '20' },
+                              ]}
+                              textStyle={{ fontSize: 10 }}
+                            >
                               {cat}
                             </Chip>
                           ))}
@@ -342,11 +368,11 @@ const handleCancelOrder = () => {
                       )}
                     </Card.Content>
                     <Card.Actions style={styles.dishActions}>
-                      <Button 
+                      <Button
                         mode="outlined"
                         icon="plus-circle"
                         onPress={() => navigateToDishCustomization(item)}
-                        style={styles.addButton}
+                        style={[styles.addButton, { borderColor: theme.colors.accent }]}
                       >
                         Ajouter
                       </Button>
@@ -375,7 +401,6 @@ const handleCancelOrder = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f0f4f8', // Fond légèrement bleuté
   },
   appbar: {
     height: 56,
@@ -398,11 +423,8 @@ const styles = StyleSheet.create({
   errorContainer: {
     margin: 16,
     padding: 16,
-    borderRadius: 8,
-    backgroundColor: '#ffe6e6',
   },
   errorText: {
-    color: '#d32f2f',
     textAlign: 'center',
   },
   sectionTitle: {
@@ -475,7 +497,6 @@ const styles = StyleSheet.create({
     marginHorizontal: 4,
     flex: 1,
     borderLeftWidth: 3,
-    borderLeftColor: '#4CAF50', // Bordure verte
   },
   dishHeader: {
     flexDirection: 'row',
@@ -492,7 +513,6 @@ const styles = StyleSheet.create({
   dishPrice: {
     fontSize: 16,
     fontWeight: 'bold',
-    color: '#4CAF50', // Prix en vert
   },
   dishCategories: {
     flexDirection: 'row',
@@ -500,7 +520,6 @@ const styles = StyleSheet.create({
     marginTop: 4,
   },
   dishCategoryChip: {
-    backgroundColor: '#E8F5E9', // Fond vert clair
     marginRight: 4,
     marginBottom: 4,
     height: 30, // Hauteur augmentée pour éviter la troncature
@@ -512,7 +531,6 @@ const styles = StyleSheet.create({
     borderTopColor: '#f0f0f0',
   },
   addButton: {
-    borderColor: '#4CAF50',
   },
   loadingDishesContainer: {
     padding: 24,

--- a/src/screens/server/ServerHomeScreen.tsx
+++ b/src/screens/server/ServerHomeScreen.tsx
@@ -5,10 +5,10 @@ import {
   Appbar,
   Text,
   ActivityIndicator,
-  Surface,
   useTheme,
   FAB,
 } from "react-native-paper";
+import GlassSurface from "../../components/common/GlassSurface";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useFocusEffect } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
@@ -620,7 +620,10 @@ export const ServerHomeScreen: React.FC<ServerHomeScreenProps> = ({
   }
 
   return (
-    <SafeAreaView style={styles.container} edges={["left", "right"]}>
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
+      edges={["left", "right"]}
+    >
       <Appbar.Header style={styles.appbar}>
         {/* Bouton de retour pour les managers */}
         {isManager && (
@@ -645,9 +648,15 @@ export const ServerHomeScreen: React.FC<ServerHomeScreenProps> = ({
 
       <View style={styles.contentContainer}>
         {error ? (
-          <Surface style={styles.errorContainer}>
-            <Text style={styles.errorText}>{error}</Text>
-          </Surface>
+          <GlassSurface
+            style={[
+              styles.errorContainer,
+            ]}
+          >
+            <Text style={[styles.errorText, { color: theme.colors.error }]}>
+              {error}
+            </Text>
+          </GlassSurface>
         ) : (
           <View style={styles.mainContent}>
             <Text style={styles.sectionTitle}>Plan de salle</Text>
@@ -703,7 +712,7 @@ export const ServerHomeScreen: React.FC<ServerHomeScreenProps> = ({
           }
         }}
         fabStyle={{
-          borderRadius: 16,
+          borderRadius: theme.roundness,
         }}
       />
 
@@ -735,7 +744,6 @@ export const ServerHomeScreen: React.FC<ServerHomeScreenProps> = ({
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#f5f5f5",
   },
   appbar: {
     height: 56,
@@ -767,11 +775,8 @@ const styles = StyleSheet.create({
   errorContainer: {
     margin: 16,
     padding: 16,
-    borderRadius: 8,
-    backgroundColor: "#ffe6e6",
   },
   errorText: {
-    color: "#d32f2f",
     textAlign: "center",
   },
   fab: {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,33 +1,60 @@
 // src/theme/theme.ts
-import { DefaultTheme } from 'react-native-paper';
+import { MD3LightTheme, MD3DarkTheme } from 'react-native-paper';
 
-// Définition des couleurs principales de l'application
-const colors = {
-  primary: '#0066CC',       // Bleu principal
-  accent: '#FF9500',        // Orange accent
-  background: '#F5F5F5',    // Fond clair
-  surface: '#FFFFFF',       // Surface des cartes et éléments
-  text: '#212121',          // Texte principal
-  error: '#D32F2F',         // Rouge pour les erreurs
-  warning: '#FFA500',       // Orange pour les avertissements
-  success: '#4CAF50',       // Vert pour les succès
-  disabled: '#9E9E9E',      // Gris pour les éléments désactivés
-  placeholder: '#9E9E9E',   // Texte placeholder
-  backdrop: 'rgba(0, 0, 0, 0.5)', // Arrière-plan modal
+// Définition des couleurs principales pour le thème clair
+const lightColors = {
+  primary: '#4F46E5', // Indigo vif pour les éléments principaux
+  accent: '#10B981', // Vert émeraude pour les actions secondaires
+  background: '#F9FAFB', // Gris très clair pour l'arrière-plan
+  surface: 'rgba(255,255,255,0.25)', // Surfaces translucides
+  text: '#111827', // Texte principal presque noir
+  error: '#EF4444', // Rouge moderne pour les erreurs
+  warning: '#F59E0B', // Orange/ambre pour les avertissements
+  success: '#10B981', // Vert pour les succès
+  disabled: '#9CA3AF', // Gris pour les éléments désactivés
+  placeholder: '#9CA3AF', // Couleur du texte placeholder
+  backdrop: 'rgba(17, 24, 39, 0.5)', // Arrière-plan modal assombri
 };
 
-// Création du thème personnalisé
-export const theme = {
-  ...DefaultTheme,
+// Palette de couleurs pour le thème sombre
+const darkColors = {
+  primary: '#818CF8', // Indigo clair pour contraste sur fond sombre
+  accent: '#34D399', // Vert émeraude lumineux
+  background: '#1F2937', // Gris foncé pour l'arrière-plan
+  surface: 'rgba(17,24,39,0.6)', // Surfaces translucides sombres
+  text: '#F9FAFB', // Texte clair
+  error: '#F87171', // Rouge plus clair
+  warning: '#FBBF24', // Jaune ambré
+  success: '#34D399', // Vert pour les succès
+  disabled: '#6B7280', // Gris pour les éléments désactivés
+  placeholder: '#9CA3AF',
+  backdrop: 'rgba(0, 0, 0, 0.5)',
+};
+
+// Thème clair
+export const lightTheme = {
+  ...MD3LightTheme,
   colors: {
-    ...DefaultTheme.colors,
-    ...colors,
+    ...MD3LightTheme.colors,
+    ...lightColors,
   },
-  roundness: 8,
-  animation: {
-    scale: 1.0,
+  roundness: 12,
+  animation: { scale: 1.0 },
+};
+
+// Thème sombre
+export const darkTheme = {
+  ...MD3DarkTheme,
+  colors: {
+    ...MD3DarkTheme.colors,
+    ...darkColors,
   },
+  roundness: 12,
+  animation: { scale: 1.0 },
 };
 
 // Types pour utiliser le thème dans l'application
-export type AppTheme = typeof theme;
+export type AppTheme = typeof lightTheme;
+
+// Export par défaut pour compatibilité
+export const theme = lightTheme;


### PR DESCRIPTION
## Summary
- add reusable glass surface component leveraging blur effect
- apply glass surfaces across login, profile, kitchen filter and server error views
- tint surface colors to translucent values for a glassmorphism feel

## Testing
- `npm run validate` (fails: expo doctor is not supported in the local CLI)
- `npx expo-doctor` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689235edb15c832f82702a09ed61fa44