### PR TITLE
fix: harmonize CreateOrder screen styling

### DIFF
--- a/src/components/kitchen/OrderCard.tsx
+++ b/src/components/kitchen/OrderCard.tsx
@@ -434,15 +434,18 @@ const styles = StyleSheet.create({
   },
   // Styles pour la modal
   modalContainer: {
+    flex: 1,
     alignItems: "center",
     justifyContent: "center",
+    padding: 16,
   },
   modalContent: {
     padding: 20,
     borderRadius: 8,
     elevation: 4,
-    width: "80%",
+    width: "90%",
     maxWidth: 400,
+    backgroundColor: "white",
   },
   modalTitle: {
     fontSize: 18,
@@ -456,6 +459,7 @@ const styles = StyleSheet.create({
   modalActions: {
     flexDirection: "row",
     justifyContent: "flex-end",
+    marginTop: 16,
   },
   modalButton: {
     marginLeft: 8,

--- a/src/screens/kitchen/KitchenHomeScreen.tsx
+++ b/src/screens/kitchen/KitchenHomeScreen.tsx
@@ -476,45 +476,48 @@ export const KitchenHomeScreen = () => {
           onPress={onRefresh}
           disabled={refreshing}
         />
-        <HeaderMenu  />
+      <HeaderMenu  />
       </Appbar.Header>
-
-      {/* Filtres de catégories */}
-      <KitchenFilter
-        categories={getAllCategories()}
-        selectedCategories={selectedCategories}
-        onSelectCategory={handleCategorySelect}
-      />
-
-      {/* Liste des commandes */}
-      <SectionList
-        sections={sections}
-        keyExtractor={(item) => item.id.toString()}
-        renderItem={({ item, section }) => (
-          <OrderCard
-            order={item}
-            status={section.status}
-            onMarkAsReady={handleMarkAsReady}
-            onReject={handleRejectItem}
-            style={styles.orderCard}
+      <View style={styles.content}>
+        {/* Filtres de catégories */}
+        <View style={styles.sectionSpacing}>
+          <KitchenFilter
+            categories={getAllCategories()}
+            selectedCategories={selectedCategories}
+            onSelectCategory={handleCategorySelect}
           />
-        )}
-        renderSectionHeader={({ section: { title } }) => (
-          <View style={styles.sectionHeader}>
-            <Text style={styles.sectionTitle}>{title}</Text>
-            <Divider style={styles.divider} />
-          </View>
-        )}
-        stickySectionHeadersEnabled={true}
-        contentContainerStyle={styles.listContent}
-        refreshing={refreshing}
-        onRefresh={onRefresh}
-        ListEmptyComponent={
-          <View style={styles.emptyContainer}>
-            <Text style={styles.emptyText}>Aucune commande disponible</Text>
-          </View>
-        }
-      />
+        </View>
+
+        {/* Liste des commandes */}
+        <SectionList
+          sections={sections}
+          keyExtractor={(item) => item.id.toString()}
+          renderItem={({ item, section }) => (
+            <OrderCard
+              order={item}
+              status={section.status}
+              onMarkAsReady={handleMarkAsReady}
+              onReject={handleRejectItem}
+              style={styles.orderCard}
+            />
+          )}
+          renderSectionHeader={({ section: { title } }) => (
+            <View style={styles.sectionHeader}>
+              <Text style={styles.sectionTitle}>{title}</Text>
+              <Divider style={styles.divider} />
+            </View>
+          )}
+          stickySectionHeadersEnabled={true}
+          contentContainerStyle={styles.listContent}
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+          ListEmptyComponent={
+            <View style={styles.emptyContainer}>
+              <Text style={styles.emptyText}>Aucune commande disponible</Text>
+            </View>
+          }
+        />
+      </View>
 
       {/* Dialogue pour les fonctionnalités non disponibles */}
       <NotAvailableDialog
@@ -589,6 +592,13 @@ const styles = StyleSheet.create({
   appbar: {
     height: 56,
     paddingTop: 0,
+  },
+  content: {
+    flex: 1,
+    padding: 16,
+  },
+  sectionSpacing: {
+    marginBottom: 16,
   },
   loadingContainer: {
     flex: 1,

--- a/src/screens/server/CreateOrderScreen.tsx
+++ b/src/screens/server/CreateOrderScreen.tsx
@@ -202,13 +202,15 @@ const handleCancelOrder = () => {
       ) : (
         <View style={styles.content}>
           {/* Panier de commande */}
-          <OrderCart 
-            onFinishOrder={handleFinishOrder}
-            onCancelOrder={handleCancelOrder}
-          />
-          
+          <View style={styles.sectionSpacing}>
+            <OrderCart
+              onFinishOrder={handleFinishOrder}
+              onCancelOrder={handleCancelOrder}
+            />
+          </View>
+
           {/* Section des catégories */}
-          <Surface style={[styles.categoriesContainer, { elevation: 4, borderRadius: 8 }]}>
+          <Surface style={[styles.categoriesContainer, styles.sectionSpacing, { elevation: 4, borderRadius: 8 }]}>
             <TouchableOpacity 
               style={[
                 styles.categoriesHeader,
@@ -384,7 +386,9 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     padding: 12,
-    gap: 16, // Espacement entre les sections
+  },
+  sectionSpacing: {
+    marginBottom: 16, // Espacement vertical entre les sections
   },
   loadingContainer: {
     flex: 1,
@@ -433,7 +437,6 @@ const styles = StyleSheet.create({
   },
   categoriesScrollContent: {
     padding: 16,
-    gap: 8,
   },
   categoriesList: {
     padding: 8,


### PR DESCRIPTION
## Summary
- replace unsupported gap styles with margin-based section spacing
- wrap OrderCart and categories sections in spacing views for consistent layout

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893094a8a94832f890e4585383d90f3