### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,12 +1,11 @@
 // App.tsx
 import React, { useEffect } from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { Provider as PaperProvider } from 'react-native-paper';
 import { StatusBar } from 'expo-status-bar';
 import { AuthProvider } from './src/contexts/AuthContext';
 import { CartProvider } from './src/contexts/CartContext';
 import { AppNavigator } from './src/navigation/AppNavigator';
-import { theme } from './src/theme/theme';
+import { ThemeProvider } from './src/contexts/ThemeContext';
 import { testConnection } from './src/api/apiConfig';
 
 export default function App() {
@@ -17,14 +16,14 @@ export default function App() {
 }, []);
   return (
     <SafeAreaProvider>
-      <PaperProvider theme={theme}>
+      <ThemeProvider>
         <StatusBar style="auto" />
         <AuthProvider>
           <CartProvider>
             <AppNavigator />
           </CartProvider>
         </AuthProvider>
-      </PaperProvider>
+      </ThemeProvider>
     </SafeAreaProvider>
   );
 }

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,34 @@
+// src/contexts/ThemeContext.tsx
+import React, { createContext, useContext, useState } from "react";
+import { PaperProvider } from "react-native-paper";
+import { darkTheme, lightTheme } from "../theme/theme";
+
+type ThemeContextType = {
+  isDarkMode: boolean;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextType>({
+  isDarkMode: false,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [isDarkMode, setIsDarkMode] = useState(false);
+
+  const toggleTheme = () => setIsDarkMode((prev) => !prev);
+
+  const theme = isDarkMode ? darkTheme : lightTheme;
+
+  return (
+    <ThemeContext.Provider value={{ isDarkMode, toggleTheme }}>
+      <PaperProvider theme={theme}>{children}</PaperProvider>
+    </ThemeContext.Provider>
+  );
+};
+
+export const useAppTheme = () => useContext(ThemeContext);
+

--- a/src/screens/ProfilScreen.tsx
+++ b/src/screens/ProfilScreen.tsx
@@ -10,16 +10,20 @@ import {
   Chip,
   Appbar,
   List,
+  Switch,
+  useTheme,
 } from "react-native-paper";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useAuth } from "../contexts/AuthContext";
-import { RolesUtils, Role } from "../utils/roles";
+import { RolesUtils } from "../utils/roles";
 import { useNavigation } from "@react-navigation/native";
-import Icon from "react-native-vector-icons/MaterialCommunityIcons";
+import { useAppTheme } from "../contexts/ThemeContext";
 
 export const ProfilScreen: React.FC = () => {
   const { user, logout, isLoading } = useAuth();
   const navigation = useNavigation();
+  const paperTheme = useTheme();
+  const { isDarkMode, toggleTheme } = useAppTheme();
 
   const handleLogout = async () => {
     await logout();
@@ -48,7 +52,10 @@ export const ProfilScreen: React.FC = () => {
   };
 
   return (
-    <SafeAreaView style={styles.container} edges={["left", "right"]}>
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: paperTheme.colors.background }]}
+      edges={["left", "right"]}
+    >
       <Appbar.Header>
         <Appbar.BackAction onPress={() => navigation.goBack()} />
         <Appbar.Content title="Mon profil" />
@@ -60,10 +67,13 @@ export const ProfilScreen: React.FC = () => {
         contentContainerStyle={styles.contentContainer}
       >
         {/* En-tête du profil */}
-        <Surface style={styles.profileHeader} elevation={2}>
+        <Surface
+          style={[styles.profileHeader, { backgroundColor: paperTheme.colors.surface }]}
+          elevation={2}
+        >
           <View style={styles.avatarContainer}>
-            <View style={styles.avatar}>
-              <Text style={styles.avatarText}>
+            <View style={[styles.avatar, { backgroundColor: paperTheme.colors.primary }]}>
+              <Text style={[styles.avatarText, { color: paperTheme.colors.onPrimary }] }>
                 {getFullName().charAt(0).toUpperCase()}
               </Text>
             </View>
@@ -107,9 +117,7 @@ export const ProfilScreen: React.FC = () => {
             <Text style={styles.sectionTitle}>Rôles et permissions</Text>
             <Divider style={styles.divider} />
 
-            <View style={styles.rolesContainer}>
-              {formatRoles(user?.roles)}
-            </View>
+            <View style={styles.rolesContainer}>{formatRoles(user?.roles)}</View>
           </Card.Content>
         </Card>
 
@@ -139,6 +147,22 @@ export const ProfilScreen: React.FC = () => {
             </Card.Content>
           </Card>
         )}
+
+        {/* Apparence */}
+        <Card style={styles.card}>
+          <Card.Content>
+            <Text style={styles.sectionTitle}>Apparence</Text>
+            <Divider style={styles.divider} />
+            <List.Item
+              title="Mode sombre"
+              left={(props) => <List.Icon {...props} icon="theme-light-dark" />}
+              right={() => (
+                <Switch value={isDarkMode} onValueChange={toggleTheme} />
+              )}
+              titleStyle={styles.listItemTitle}
+            />
+          </Card.Content>
+        </Card>
 
         {/* Bouton de déconnexion */}
         <Button

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,27 +1,54 @@
 // src/theme/theme.ts
-import { DefaultTheme } from 'react-native-paper';
+import { MD3LightTheme, MD3DarkTheme } from "react-native-paper";
 
-// Définition des couleurs principales de l'application
-const colors = {
-  primary: '#0066CC',       // Bleu principal
-  accent: '#FF9500',        // Orange accent
-  background: '#F5F5F5',    // Fond clair
-  surface: '#FFFFFF',       // Surface des cartes et éléments
-  text: '#212121',          // Texte principal
-  error: '#D32F2F',         // Rouge pour les erreurs
-  warning: '#FFA500',       // Orange pour les avertissements
-  success: '#4CAF50',       // Vert pour les succès
-  disabled: '#9E9E9E',      // Gris pour les éléments désactivés
-  placeholder: '#9E9E9E',   // Texte placeholder
-  backdrop: 'rgba(0, 0, 0, 0.5)', // Arrière-plan modal
+// Définition des couleurs principales de l'application pour le mode clair
+const lightColors = {
+  primary: "#0066CC", // Bleu principal
+  accent: "#FF9500", // Orange accent
+  background: "#F5F5F5", // Fond clair
+  surface: "#FFFFFF", // Surface des cartes et éléments
+  text: "#212121", // Texte principal
+  error: "#D32F2F", // Rouge pour les erreurs
+  warning: "#FFA500", // Orange pour les avertissements
+  success: "#4CAF50", // Vert pour les succès
+  disabled: "#9E9E9E", // Gris pour les éléments désactivés
+  placeholder: "#9E9E9E", // Texte placeholder
+  backdrop: "rgba(0, 0, 0, 0.5)", // Arrière-plan modal
 };
 
-// Création du thème personnalisé
-export const theme = {
-  ...DefaultTheme,
+// Définition des couleurs principales pour le mode sombre
+const darkColors = {
+  primary: "#0066CC",
+  accent: "#FF9500",
+  background: "#121212", // Fond sombre
+  surface: "#1E1E1E", // Surface sombre
+  text: "#FFFFFF", // Texte principal
+  error: "#CF6679", // Rouge pour les erreurs en mode sombre
+  warning: "#FFA500",
+  success: "#4CAF50",
+  disabled: "#9E9E9E",
+  placeholder: "#9E9E9E",
+  backdrop: "rgba(0, 0, 0, 0.5)",
+};
+
+// Création des thèmes personnalisés
+export const lightTheme = {
+  ...MD3LightTheme,
   colors: {
-    ...DefaultTheme.colors,
-    ...colors,
+    ...MD3LightTheme.colors,
+    ...lightColors,
+  },
+  roundness: 8,
+  animation: {
+    scale: 1.0,
+  },
+};
+
+export const darkTheme = {
+  ...MD3DarkTheme,
+  colors: {
+    ...MD3DarkTheme.colors,
+    ...darkColors,
   },
   roundness: 8,
   animation: {
@@ -30,4 +57,4 @@ export const theme = {
 };
 
 // Types pour utiliser le thème dans l'application
-export type AppTheme = typeof theme;
+export type AppTheme = typeof lightTheme;


### PR DESCRIPTION
## Summary
- add light and dark theme definitions
- provide theme context and wrap app
- allow toggling dark mode from profile screen

## Testing
- `npm test` (fails: Missing script: "test")
- `npx tsc --noEmit` (fails: Option 'customConditions' can only be used when 'moduleResolution' is set to 'node16', 'nodenext', or 'bundler')

------
https://chatgpt.com/codex/tasks/task_e_6893163d2300832f95e7ca32a9f949c3