### PR TITLE
feat: add basic ESC/POS printing support

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,6 +8,7 @@ import { CartProvider } from './src/contexts/CartContext';
 import { AppNavigator } from './src/navigation/AppNavigator';
 import { theme } from './src/theme/theme';
 import { testConnection } from './src/api/apiConfig';
+import { PrintersProvider } from './src/contexts/PrintersContext';
 
 export default function App() {
   useEffect(() => {
@@ -21,7 +22,9 @@ export default function App() {
         <StatusBar style="auto" />
         <AuthProvider>
           <CartProvider>
-            <AppNavigator />
+            <PrintersProvider>
+              <AppNavigator />
+            </PrintersProvider>
           </CartProvider>
         </AuthProvider>
       </PaperProvider>

--- a/src/contexts/PrintersContext.tsx
+++ b/src/contexts/PrintersContext.tsx
@@ -1,0 +1,93 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Printer } from '../types/printer';
+
+interface PrintersContextValue {
+  printers: Printer[];
+  kitchenPrinterId: string | null;
+  receiptPrinterId: string | null;
+  addPrinter: (p: Printer) => void;
+  removePrinter: (id: string) => void;
+  setDefaultPrinter: (type: 'kitchen' | 'receipt', id: string) => void;
+}
+
+const PrintersContext = createContext<PrintersContextValue | undefined>(undefined);
+
+export const usePrinters = () => {
+  const ctx = useContext(PrintersContext);
+  if (!ctx) {
+    throw new Error('usePrinters must be used within a PrintersProvider');
+  }
+  return ctx;
+};
+
+interface ProviderProps {
+  children: React.ReactNode;
+}
+
+const STORAGE_KEY = 'printers-config';
+
+export const PrintersProvider: React.FC<ProviderProps> = ({ children }) => {
+  const [printers, setPrinters] = useState<Printer[]>([]);
+  const [kitchenPrinterId, setKitchenPrinterId] = useState<string | null>(null);
+  const [receiptPrinterId, setReceiptPrinterId] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const raw = await AsyncStorage.getItem(STORAGE_KEY);
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          setPrinters(parsed.printers || []);
+          setKitchenPrinterId(parsed.kitchenPrinterId || null);
+          setReceiptPrinterId(parsed.receiptPrinterId || null);
+        }
+      } catch (e) {
+        console.warn('Failed to load printers configuration', e);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    const save = async () => {
+      try {
+        await AsyncStorage.setItem(
+          STORAGE_KEY,
+          JSON.stringify({ printers, kitchenPrinterId, receiptPrinterId })
+        );
+      } catch (e) {
+        console.warn('Failed to save printers configuration', e);
+      }
+    };
+    save();
+  }, [printers, kitchenPrinterId, receiptPrinterId]);
+
+  const addPrinter = (p: Printer) => {
+    setPrinters(prev => [...prev.filter(pr => pr.id !== p.id), p]);
+  };
+
+  const removePrinter = (id: string) => {
+    setPrinters(prev => prev.filter(pr => pr.id !== id));
+    if (kitchenPrinterId === id) setKitchenPrinterId(null);
+    if (receiptPrinterId === id) setReceiptPrinterId(null);
+  };
+
+  const setDefaultPrinter = (type: 'kitchen' | 'receipt', id: string) => {
+    if (type === 'kitchen') {
+      setKitchenPrinterId(id);
+    } else {
+      setReceiptPrinterId(id);
+    }
+  };
+
+  const value: PrintersContextValue = {
+    printers,
+    kitchenPrinterId,
+    receiptPrinterId,
+    addPrinter,
+    removePrinter,
+    setDefaultPrinter,
+  };
+
+  return <PrintersContext.Provider value={value}>{children}</PrintersContext.Provider>;
+};

--- a/src/hooks/usePrinter.ts
+++ b/src/hooks/usePrinter.ts
@@ -1,116 +1,138 @@
-// src/hooks/usePrinter.ts
 import { useState, useCallback } from 'react';
+import { Printer } from '../types/printer';
 
-interface PrinterState {
-  isConnected: boolean;
-  printerName: string | null;
+let NetPrinter: any = null;
+let BLEPrinter: any = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const Printers = require('react-native-thermal-receipt-printer');
+  NetPrinter = Printers.NetPrinter;
+  BLEPrinter = Printers.BLEPrinter;
+} catch (e) {
+  // Library not installed; hook will fail gracefully
+  console.warn('Printer library not available', e);
+}
+
+interface PrinterHookState {
+  connectedPrinter: Printer | null;
   isLoading: boolean;
   error: string | null;
 }
 
 export interface PrintOptions {
   copies?: number;
-  preview?: boolean;
 }
 
-// Hook personnalisé pour la gestion des imprimantes
 export const usePrinter = () => {
-  const [state, setState] = useState<PrinterState>({
-    isConnected: false,
-    printerName: null,
+  const [state, setState] = useState<PrinterHookState>({
+    connectedPrinter: null,
     isLoading: false,
-    error: null
+    error: null,
   });
 
-  // Simuler la connexion à une imprimante
-  const connectPrinter = useCallback(async () => {
-    setState(prev => ({ ...prev, isLoading: true, error: null }));
-    
+  const scanPrinters = useCallback(async (): Promise<Printer[]> => {
+    const devices: Printer[] = [];
     try {
-      // Simulation de délai de connexion
-      await new Promise(resolve => setTimeout(resolve, 1500));
-      
-      // Simuler une connexion réussie
-      setState({
-        isConnected: true,
-        printerName: 'Imprimante de cuisine',
-        isLoading: false,
-        error: null
-      });
-      
+      if (NetPrinter?.scan) {
+        const nets = await NetPrinter.scan();
+        nets.forEach((d: any) =>
+          devices.push({
+            id: d.ip || d.host,
+            type: 'net',
+            host: d.ip || d.host,
+            port: d.port || 9100,
+            name: d.device_name || d.host || d.ip,
+          })
+        );
+      }
+      if (BLEPrinter?.scan) {
+        const bles = await BLEPrinter.scan();
+        bles.forEach((d: any) =>
+          devices.push({
+            id: d.macAddress || d.address,
+            type: 'ble',
+            macAddress: d.macAddress || d.address,
+            name: d.deviceName || d.name,
+          })
+        );
+      }
+    } catch (err: any) {
+      setState(prev => ({ ...prev, error: err.message }));
+    }
+    return devices;
+  }, []);
+
+  const connectPrinter = useCallback(async (printer: Printer) => {
+    setState(prev => ({ ...prev, isLoading: true, error: null }));
+    try {
+      if (printer.type === 'net' && NetPrinter) {
+        await NetPrinter.connectPrinter(printer.host, printer.port || 9100);
+      } else if (printer.type === 'ble' && BLEPrinter) {
+        await BLEPrinter.connectPrinter(printer.macAddress);
+      } else {
+        throw new Error('Unsupported printer type');
+      }
+      setState({ connectedPrinter: printer, isLoading: false, error: null });
       return true;
-    } catch (error: any) {
-      setState(prev => ({
-        ...prev,
-        isLoading: false,
-        error: error.message || 'Erreur de connexion à l\'imprimante'
-      }));
+    } catch (err: any) {
+      setState(prev => ({ ...prev, isLoading: false, error: err.message }));
       return false;
     }
   }, []);
 
-  // Simuler la déconnexion d'une imprimante
   const disconnectPrinter = useCallback(async () => {
-    setState(prev => ({ ...prev, isLoading: true }));
-    
+    const { connectedPrinter } = state;
+    if (!connectedPrinter) return;
     try {
-      // Simulation de délai de déconnexion
-      await new Promise(resolve => setTimeout(resolve, 500));
-      
-      setState({
-        isConnected: false,
-        printerName: null,
-        isLoading: false,
-        error: null
-      });
-      
-      return true;
-    } catch (error: any) {
-      setState(prev => ({
-        ...prev,
-        isLoading: false,
-        error: error.message || 'Erreur de déconnexion de l\'imprimante'
-      }));
-      return false;
+      if (connectedPrinter.type === 'net' && NetPrinter?.disconnectPrinter) {
+        await NetPrinter.disconnectPrinter();
+      } else if (
+        connectedPrinter.type === 'ble' &&
+        BLEPrinter?.disconnectPrinter
+      ) {
+        await BLEPrinter.disconnectPrinter();
+      }
+    } catch (err: any) {
+      setState(prev => ({ ...prev, error: err.message }));
+    } finally {
+      setState({ connectedPrinter: null, isLoading: false, error: null });
     }
-  }, []);
+  }, [state.connectedPrinter]);
 
-  // Simuler l'impression d'un document
-  const printDocument = useCallback(async (content: string, options?: PrintOptions) => {
-    if (!state.isConnected) {
-      setState(prev => ({
-        ...prev,
-        error: 'Aucune imprimante connectée'
-      }));
-      return false;
-    }
-    
-    setState(prev => ({ ...prev, isLoading: true, error: null }));
-    
-    try {
-      // Simulation de délai d'impression
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      
-      console.log(`Impression: ${content}`);
-      console.log(`Options: ${JSON.stringify(options || {})}`);
-      
-      setState(prev => ({ ...prev, isLoading: false }));
-      
-      return true;
-    } catch (error: any) {
-      setState(prev => ({
-        ...prev,
-        isLoading: false,
-        error: error.message || 'Erreur d\'impression'
-      }));
-      return false;
-    }
-  }, [state.isConnected]);
+  const print = useCallback(
+    async (text: string, _options?: PrintOptions) => {
+      if (!state.connectedPrinter) {
+        setState(prev => ({ ...prev, error: 'Aucune imprimante connectée' }));
+        return false;
+      }
+      try {
+        if (state.connectedPrinter.type === 'net' && NetPrinter?.printText) {
+          await NetPrinter.printText(text);
+        } else if (
+          state.connectedPrinter.type === 'ble' &&
+          BLEPrinter?.printText
+        ) {
+          await BLEPrinter.printText(text);
+        } else {
+          throw new Error('Fonction d\'impression non disponible');
+        }
+        return true;
+      } catch (err: any) {
+        setState(prev => ({ ...prev, error: err.message }));
+        return false;
+      }
+    },
+    [state.connectedPrinter]
+  );
 
   return {
-    ...state,
+    connectedPrinter: state.connectedPrinter,
+    isConnected: !!state.connectedPrinter,
+    isLoading: state.isLoading,
+    error: state.error,
+    scanPrinters,
     connectPrinter,
     disconnectPrinter,
-    printDocument
+    print,
   };
 };

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -18,6 +18,7 @@ import { DomainOrderItem } from "../api/orderService";
 import { ManagerHomeScreen } from "../screens/manager/ManagerHomeScreen";
 import { CloseWithDebtScreen } from "../screens/server/CloseWithDebtScreen";
 import { PendingValidationsScreen } from "../screens/manager/PendingValidationsScreen";
+import { PrinterConfigScreen } from "../screens/server/PrinterConfigScreen";
 import { useAuth } from "../contexts/AuthContext";
 import { ActivityIndicator, View, StyleSheet, Text } from "react-native";
 
@@ -77,6 +78,7 @@ export type MainStackParamList = {
     numberOfPeople: number;
     currency: string;
   };
+  PrinterConfig: undefined;
 };
 
 // Créer les navigateurs
@@ -138,6 +140,7 @@ const MainNavigator: React.FC = () => {
       <MainStack.Screen name="PaymentScreen" component={PaymentScreen} />
       <MainStack.Screen name="CloseWithDebt" component={CloseWithDebtScreen} />
       <MainStack.Screen name="PendingValidations" component={PendingValidationsScreen} />
+      <MainStack.Screen name="PrinterConfig" component={PrinterConfigScreen} />
     </MainStack.Navigator>
   );
 };

--- a/src/screens/server/PrinterConfigScreen.tsx
+++ b/src/screens/server/PrinterConfigScreen.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import { View, ScrollView } from 'react-native';
+import {
+  Appbar,
+  Button,
+  List,
+  TextInput,
+  Divider,
+  Text,
+} from 'react-native-paper';
+import { usePrinter } from '../../hooks/usePrinter';
+import { usePrinters } from '../../contexts/PrintersContext';
+import { Printer } from '../../types/printer';
+
+export const PrinterConfigScreen: React.FC<any> = ({ navigation }) => {
+  const { printers, addPrinter, removePrinter, setDefaultPrinter, kitchenPrinterId, receiptPrinterId } = usePrinters();
+  const { scanPrinters, connectPrinter, print } = usePrinter();
+  const [available, setAvailable] = useState<Printer[]>([]);
+  const [ip, setIp] = useState('');
+  const [port, setPort] = useState('9100');
+
+  const handleScan = async () => {
+    const res = await scanPrinters();
+    setAvailable(res);
+  };
+
+  const handleAddManual = () => {
+    if (!ip) return;
+    const printer: Printer = {
+      id: ip,
+      type: 'net',
+      host: ip,
+      port: parseInt(port, 10) || 9100,
+      name: ip,
+    };
+    addPrinter(printer);
+    setIp('');
+  };
+
+  const handleTestPrint = async (printer: Printer) => {
+    await connectPrinter(printer);
+    await print('[C]Test d\'impression');
+  };
+
+  return (
+    <View style={{ flex: 1 }}>
+      <Appbar.Header>
+        <Appbar.BackAction onPress={() => navigation.goBack()} />
+        <Appbar.Content title="Configuration d'impression" />
+      </Appbar.Header>
+      <ScrollView style={{ flex: 1, padding: 16 }}>
+        <Button mode="contained" onPress={handleScan} icon="magnify">
+          Rechercher des imprimantes
+        </Button>
+
+        {available.length > 0 && (
+          <>
+            <List.Subheader>Imprimantes détectées</List.Subheader>
+            {available.map((p) => (
+              <List.Item
+                key={p.id}
+                title={p.name}
+                description={p.host || p.macAddress}
+                right={() => (
+                  <Button onPress={() => addPrinter(p)}>Enregistrer</Button>
+                )}
+              />
+            ))}
+            <Divider style={{ marginVertical: 8 }} />
+          </>
+        )}
+
+        <List.Subheader>Ajouter manuellement</List.Subheader>
+        <TextInput label="Adresse IP" value={ip} onChangeText={setIp} style={{ marginBottom: 8 }} />
+        <TextInput label="Port" value={port} onChangeText={setPort} keyboardType="numeric" style={{ marginBottom: 8 }} />
+        <Button onPress={handleAddManual}>Ajouter</Button>
+
+        <Divider style={{ marginVertical: 16 }} />
+        <List.Subheader>Imprimantes enregistrées</List.Subheader>
+        {printers.length === 0 && <Text>Aucune imprimante enregistrée</Text>}
+        {printers.map((p) => (
+          <List.Item
+            key={p.id}
+            title={p.name}
+            description={p.host || p.macAddress}
+            left={() => (
+              <List.Icon icon={p.id === kitchenPrinterId || p.id === receiptPrinterId ? 'check' : 'printer'} />
+            )}
+            right={() => (
+              <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                <Button onPress={() => setDefaultPrinter('kitchen', p.id)} compact>
+                  Cuisine
+                </Button>
+                <Button onPress={() => setDefaultPrinter('receipt', p.id)} compact>
+                  Addition
+                </Button>
+                <Button onPress={() => handleTestPrint(p)} compact>
+                  Test
+                </Button>
+                <Button onPress={() => removePrinter(p.id)} compact>
+                  Supprimer
+                </Button>
+              </View>
+            )}
+          />
+        ))}
+      </ScrollView>
+    </View>
+  );
+};

--- a/src/types/printer.ts
+++ b/src/types/printer.ts
@@ -1,0 +1,8 @@
+export interface Printer {
+  id: string;
+  type: 'net' | 'ble';
+  name: string;
+  host?: string;
+  port?: number;
+  macAddress?: string;
+}

--- a/src/utils/buildOrderTicket.ts
+++ b/src/utils/buildOrderTicket.ts
@@ -1,0 +1,21 @@
+import { DomainOrder } from '../api/orderService';
+
+export const buildOrderTicket = (order: DomainOrder): string => {
+  const lines: string[] = [];
+  lines.push(`[C]<BOLD>COMMANDE #${order.id}</BOLD>`);
+  lines.push(`[L]Table: ${order.tableName}`);
+  lines.push(`[L]Date: ${new Date(order.orderDate).toLocaleString()}`);
+  lines.push('[L]------------------------------');
+
+  order.items.forEach((item) => {
+    lines.push(`[L]${item.count} x ${item.dishName}`);
+  });
+
+  lines.push('[L]------------------------------');
+  lines.push(
+    `[R]TOTAL: ${order.totalPrice.toFixed(2)} ${order.currency.code}`
+  );
+  lines.push('[C]Merci!');
+
+  return lines.join('\n');
+};

--- a/src/utils/buildReceipt.ts
+++ b/src/utils/buildReceipt.ts
@@ -1,0 +1,40 @@
+interface ReceiptParams {
+  orderId: number;
+  tableName?: string;
+  totalAmount: number;
+  paidAmount: number;
+  paymentAmount: number;
+  receivedAmount: number;
+  change: number;
+  currency: string;
+}
+
+export const buildReceipt = ({
+  orderId,
+  tableName,
+  totalAmount,
+  paidAmount,
+  paymentAmount,
+  receivedAmount,
+  change,
+  currency,
+}: ReceiptParams): string => {
+  const lines = [
+    '[C]<BOLD>RESTAURANT XYZ</BOLD>',
+    '[C]--------------------------------',
+    `[L]Table: ${tableName || 'N/A'}`,
+    `[L]Commande #${orderId}`,
+    `[L]Date: ${new Date().toLocaleString()}`,
+    '[L]--------------------------------',
+    `[L]Montant total: ${totalAmount.toFixed(2)} ${currency}`,
+    `[L]Montant payé précédemment: ${paidAmount.toFixed(2)} ${currency}`,
+    `[L]Montant de ce paiement: ${paymentAmount.toFixed(2)} ${currency}`,
+    `[L]Montant reçu: ${receivedAmount.toFixed(2)} ${currency}`,
+    `[L]Monnaie rendue: ${change.toFixed(2)} ${currency}`,
+    `[L]Reste à payer: ${Math.max(0, totalAmount - (paidAmount + paymentAmount)).toFixed(2)} ${currency}`,
+    '[C]--------------------------------',
+    '[C]Merci de votre visite!',
+  ];
+
+  return lines.join('\n');
+};


### PR DESCRIPTION
## Summary
- add reusable `usePrinter` hook to scan, connect and print to ESC/POS printers
- store printer settings with `PrintersContext` and AsyncStorage
- provide ticket/receipt formatting helpers and configuration screen

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit` *(fails: Option 'customConditions' can only be used when 'moduleResolution' is set to supported values)*

------
https://chatgpt.com/codex/tasks/task_e_689998c93058832f9e1acde32a7de609